### PR TITLE
Add automated pandoc-based PDF generation via GitHub Actions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,6 +45,30 @@ jobs:
       - name: Build website
         run: yarn build
 
+      - name: Install Pandoc and LaTeX
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc texlive-latex-base texlive-fonts-recommended texlive-latex-extra
+
+      - name: Generate PDF manual
+        working-directory: live-stream-manual/docs
+        run: |
+          pandoc index.md equipment-overview.md camera-setup.md \
+            operations/system-startup.mdx operations/service-timeline-10am.mdx operations/pre-doors-checklist.mdx \
+            roles/director.md roles/graphics-producer.md roles/stream-producer.md \
+            roles/imag-director.md roles/camera-operator.md \
+            --toc \
+            --toc-depth=3 \
+            --number-sections \
+            --standalone \
+            --metadata title="Livestream Operations Manual" \
+            --metadata author="St Aldate's Church" \
+            --metadata date="$(date +%Y-%m-%d)" \
+            -V documentclass=report \
+            -V geometry:margin=1in \
+            -V fontsize=11pt \
+            -o ../static/livestream-manual.pdf
+
       - name: Upload Pages artifact (for deployment)
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v4
@@ -58,6 +82,13 @@ jobs:
           name: docusaurus-build
           path: live-stream-manual/build
           retention-days: 30
+
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: livestream-manual-pdf
+          path: live-stream-manual/static/livestream-manual.pdf
+          retention-days: 90
 
   deploy:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Pandoc and LaTeX
         run: |
           sudo apt-get update
-          sudo apt-get install -y pandoc texlive-latex-base texlive-fonts-recommended texlive-latex-extra
+          sudo apt-get install -y pandoc texlive-latex-base texlive-fonts-recommended texlive-latex-extra texlive-xetex
 
       - name: Generate PDF manual
         working-directory: live-stream-manual/docs
@@ -61,6 +61,7 @@ jobs:
             --toc-depth=3 \
             --number-sections \
             --standalone \
+            --pdf-engine=xelatex \
             --metadata title="Livestream Operations Manual" \
             --metadata author="St Aldate's Church" \
             --metadata date="$(date +%Y-%m-%d)" \

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -54,9 +54,7 @@ jobs:
         working-directory: live-stream-manual/docs
         run: |
           pandoc index.md equipment-overview.md camera-setup.md \
-            operations/system-startup.mdx operations/service-timeline-10am.mdx operations/pre-doors-checklist.mdx \
-            roles/director.md roles/graphics-producer.md roles/stream-producer.md \
-            roles/imag-director.md roles/camera-operator.md \
+            roles/*.md \
             --toc \
             --toc-depth=3 \
             --number-sections \

--- a/live-stream-manual/docs/index.md
+++ b/live-stream-manual/docs/index.md
@@ -7,6 +7,8 @@ layout: default
 
 # Livestream Operations Manual
 
+📄 **[Download PDF version of this manual](pathname:///livestream-manual.pdf)** _(Generated automatically from the latest documentation)_
+
 ## Overview
 
 This manual provides guidance for operating our church livestream services. Our livestream serves both the congregation in the room and those watching online. The goal is clear communication of what God is doing in the service.

--- a/live-stream-manual/static/.gitkeep
+++ b/live-stream-manual/static/.gitkeep
@@ -1,0 +1,1 @@
+Static assets folder for Docusaurus


### PR DESCRIPTION
- Install Pandoc and LaTeX in build workflow
- Generate PDF from markdown docs with TOC and metadata
- Store PDF in static/ folder for Docusaurus deployment
- Upload PDF as build artifact (90 day retention)
- Add download link to manual homepage